### PR TITLE
Only show non-empty contexts

### DIFF
--- a/PSKubeContext.psm1
+++ b/PSKubeContext.psm1
@@ -56,7 +56,7 @@ Function Select-KubeContext {
         }
         else {
             $allCtx = & kubectl config get-contexts -o=name
-            $ctx = Select-MenuOption -MenuOptions $allCtx;
+            $ctx = Select-MenuOption -MenuOptions $allCtx.Where({ $_ -ne '' });
         }
     }
     process {


### PR DESCRIPTION
On my system there is an empty option at first position. Filtering results on `-ne ''` solves this.